### PR TITLE
Make libft copy instead of move pls

### DIFF
--- a/Test/LibFT/run-test.sh
+++ b/Test/LibFT/run-test.sh
@@ -12,7 +12,7 @@ rm -rf "$HOME/goinfre/RUN_TEST"
 mkdir -p "$HOME/goinfre/RUN_TEST"
 mkdir -p "$HOME/goinfre/RUN_TEST/PROJECT"
 mkdir -p "$HOME/goinfre/RUN_TEST/RESULTS"
-mv "$1" "$HOME/goinfre/RUN_TEST/PROJECT"
+cp -r "$1" "$HOME/goinfre/RUN_TEST/PROJECT"
 cd "$HOME/goinfre/RUN_TEST/PROJECT/$1" || exit
 git clone --quiet https://github.com/Tripouille/libftTester
 cd ..


### PR DESCRIPTION
I want to make a script that downloads your .sh and runs it. but I don't want people to lose their libft folders if something goes wrong. If you dont apply the changes, I'm gonna copy your whole run-test-sh and put it in my git.